### PR TITLE
Fixed some bugs and implemented some things

### DIFF
--- a/playphrase/src/main/java/dragon/tamu/playphrase/EditActivity.java
+++ b/playphrase/src/main/java/dragon/tamu/playphrase/EditActivity.java
@@ -36,6 +36,7 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
     //Add Phrase/Category members
     private FloatingActionButton fab, addPhraseButton, addCategoryButton;
     private TextView addCat, addPhrase;
+    private View maskView;
     private boolean isFabOpen;
     private Animation rotate_forward, rotate_backward, fab_open, fab_close, slide_in, slide_out;
 
@@ -64,6 +65,8 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
         //Code for action button labels
         addPhrase = (TextView) findViewById(R.id.fab1_tView);
         addCat = (TextView) findViewById(R.id.fab2_tView);
+        //Dark background
+        maskView = findViewById(R.id.dark_opaque_background);
         //Animations for fab
         rotate_backward = AnimationUtils.loadAnimation(getApplicationContext(), R.anim.rotate_backward);
         rotate_forward = AnimationUtils.loadAnimation(getApplicationContext(), R.anim.rotate_forward);
@@ -114,11 +117,8 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
     {
         if (getFragmentManager().getBackStackEntryCount() > 0)
         {
+            maskView.setVisibility(View.INVISIBLE);
             getFragmentManager().popBackStack();
-            if(getFragmentManager().findFragmentByTag("phrase_add_frag") instanceof RecordingFragment) {
-                RecordingFragment recFrag = (RecordingFragment) getFragmentManager().findFragmentByTag("phrase_add_frag");
-                if (recFrag.getSnackbarStatus()) recFrag.dismissSnackbar();
-            }
             fab.show();
         }
         else
@@ -211,7 +211,6 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
 
         if (isFabOpen)
         {
-
             fab.startAnimation(rotate_backward);
             addPhraseButton.startAnimation(fab_close);
             addCategoryButton.startAnimation(fab_close);
@@ -220,8 +219,7 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
             addPhraseButton.setClickable(false);
             addCategoryButton.setClickable(false);
             isFabOpen = false;
-
-
+            maskView.setVisibility(View.INVISIBLE);
         }
         else
         {
@@ -233,6 +231,7 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
             addPhraseButton.setClickable(true);
             addCategoryButton.setClickable(true);
             isFabOpen = true;
+            maskView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -249,6 +248,7 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
         fragment.setArguments(args);
         animateFAB();
         fab.hide();
+        maskView.setVisibility(View.VISIBLE);
         getFragmentManager().beginTransaction().add(R.id.edit_coord_layout, fragment, "phrase_add_frag").addToBackStack(null).commit();
         /* CoordinatorLayout root = (CoordinatorLayout) findViewById( R.id.edit_coord_layout );
          DisplayMetrics dm = new DisplayMetrics();
@@ -309,9 +309,22 @@ public class EditActivity extends AppCompatActivity implements OnStartDragListen
             addCategory(catName);
             catIndex = 0;
         }
-        Phrase pr = fileSystem.addPhrase(phraseText, langName, catName, filePath);
-        ((Category) mCategoryList.get(catIndex)).addPhrase(pr);
-        mAdapter.notifyChildItemInserted(catIndex, 0);
+        Phrase pr = fileSystem.addPhrase(phraseText, langName, filePath, catName);
+        boolean phraseExists = false;
+        for (int i = 0; i < mCategoryList.size(); i++) {
+            Category c = (Category) mCategoryList.get(i);
+            for (int j = 0; j < c.phraseList.size(); j++) {
+                Phrase p = (Phrase) c.phraseList.get(j);
+                if (p.getPhraseText().equals(phraseText)) {
+                    phraseExists = true;
+                    break;
+                }
+            }
+        }
+        if (!phraseExists) {
+            ((Category) mCategoryList.get(catIndex)).addPhrase(pr);
+            mAdapter.notifyChildItemInserted(catIndex, 0);
+        }
 
     }
 

--- a/playphrase/src/main/java/dragon/tamu/playphrase/RecordingFragment.java
+++ b/playphrase/src/main/java/dragon/tamu/playphrase/RecordingFragment.java
@@ -1042,6 +1042,8 @@ public class RecordingFragment extends Fragment {
                 final String fPath = filePath;
                 final String cName = categoryName;
 
+
+                //TODO get this portion of code working
                 snackbar = Snackbar
                         .make(getView(), "Continuing will overwrite existing phrase. Continue anyways?", Snackbar.LENGTH_INDEFINITE)
                         .setAction("CONTINUE", new View.OnClickListener() {
@@ -1054,10 +1056,6 @@ public class RecordingFragment extends Fragment {
 //                                fileSystem.addPhrase(pName, lName + lAbbr, fPath, cName);
 //                                Log.d("Recording Fragment", "Added Phrase");
 //                                //((EditActivity) getActivity()).loadList();
-                                addLanguage(finalLangName, finalLangAbbr);
-                                ((EditActivity) getActivity()).addPhrase(pName, cName, lName + lAbbr, fPath);
-
-                                getActivity().onBackPressed();
                                 Snackbar snackbar1 = Snackbar
                                         .make(getView(), "Saved!", Snackbar.LENGTH_SHORT);
 
@@ -1074,6 +1072,11 @@ public class RecordingFragment extends Fragment {
                 Log.d("Recording Fragment","Phrase already exists");
 
                 snackbar.show();
+            } else {
+                addLanguage(finalLangName, finalLangAbbr);
+                ((EditActivity) getActivity()).addPhrase(phraseName, categoryName, language, filePath);
+
+                getActivity().onBackPressed();
             }
         }
 

--- a/playphrase/src/main/res/layout-h1280dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h1280dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="80dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="80dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="80dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="80dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="80dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h569dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h569dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h600dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h600dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -164,12 +165,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:background="#FFFFFFFF"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h640dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h640dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
-            android:outlineProvider="bounds"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Phrase_choices"
+            android:outlineProvider="bounds"
+            android:padding="12dp"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -166,8 +167,8 @@
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -175,8 +176,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -193,8 +194,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -204,22 +205,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -227,10 +228,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -238,21 +239,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h731dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h731dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h800dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h800dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h853dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h853dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout-h960dp/recording_fragment.xml
+++ b/playphrase/src/main/res/layout-h960dp/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="20dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="20dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -105,11 +106,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="20dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/layout/activity_edit.xml
+++ b/playphrase/src/main/res/layout/activity_edit.xml
@@ -7,23 +7,28 @@
     android:layout_height="match_parent"
     android:background="#a29f9f"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="dragon.tamu.playphrase.EditActivity">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/edit_list_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_margin="15dp"
 
         />
+
+    <View
+        android:id="@+id/dark_opaque_background"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#c0000000"
+        android:visibility="invisible" />
 
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|right"
+        android:layout_margin="15dp"
 
         >
     <android.support.design.widget.FloatingActionButton
@@ -75,7 +80,7 @@
             android:layout_toLeftOf="@id/fab2"
             android:gravity="center_vertical"
             android:text="@string/add_category"
-            android:textColor="#000000"
+            android:textColor="#FFFFFFFF"
             android:visibility="invisible" />
 
         <TextView
@@ -88,7 +93,7 @@
             android:layout_toLeftOf="@id/fab1"
             android:gravity="center_vertical"
             android:text="@string/add_phrase"
-            android:textColor="#000000"
+            android:textColor="#FFFFFFFF"
             android:visibility="invisible" />
     </RelativeLayout>
 

--- a/playphrase/src/main/res/layout/activity_main.xml
+++ b/playphrase/src/main/res/layout/activity_main.xml
@@ -16,46 +16,31 @@
         android:paddingLeft="@dimen/activity_horizontal_margin"
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingTop="@dimen/activity_vertical_margin">
-        <!--<android.support.design.widget.FloatingActionButton-->
-            <!--android:layout_width="wrap_content"-->
-            <!--android:layout_height="wrap_content"-->
-            <!--android:layout_alignParentBottom="true"-->
-            <!--android:layout_alignParentRight="true"-->
-            <!--android:layout_marginBottom="20dp"-->
-            <!--android:layout_marginRight="15dp"-->
-            <!--android:src="@drawable/ic_action_add"-->
-            <!--android:id="@+id/floating_button"/>-->
         <android.support.v7.widget.SearchView
             android:id="@+id/search_view"
-            android:layout_centerHorizontal="true"
-            app:queryHint="@string/searchable_hint"
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:background="#ffffff"
             app:iconifiedByDefault="false"
-            android:background="#ffffff" />
+            app:queryHint="@string/searchable_hint" />
         <android.support.v7.widget.RecyclerView
+            android:id="@+id/expandableListView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:id="@+id/expandableListView"
-            android:layout_below="@id/search_view"
             android:layout_alignParentLeft="true"
-            android:layout_marginTop="10dp"
+            android:layout_below="@id/search_view"
             android:layout_marginBottom="5dp"
+            android:layout_marginTop="10dp"
             />
-        <!--<View-->
-            <!--android:layout_width="match_parent"-->
-            <!--android:layout_height="1dp"-->
-            <!--android:layout_marginBottom="4dp"-->
-            <!--android:layout_above="@id/floating_button"-->
-            <!--android:background="@android:color/darker_gray"/>-->
     </RelativeLayout>
 
 
     <!-- The navigation drawer -->
     <RelativeLayout
+        android:id="@+id/drawerPane"
         android:layout_width="280dp"
         android:layout_height="match_parent"
-        android:id="@+id/drawerPane"
         android:layout_gravity="start">
     <RelativeLayout
         android:id="@+id/languageTitle"
@@ -64,25 +49,38 @@
         android:background="@color/material_blue_grey_800"
         android:padding="8dp" >
         <TextView
+            style="@style/TextAppearance.AppCompat.Title"
             android:layout_width="match_parent"
             android:layout_height="100dp"
-            android:text="@string/drawer_title"
-            android:textStyle="bold"
-            android:textSize="23sp"
             android:layout_marginTop="15dp"
             android:padding="8dp"
+            android:text="@string/drawer_title"
             android:textColor="#FFFFFF"
-            style="@style/TextAppearance.AppCompat.Title" /></RelativeLayout>
+            android:textSize="23sp"
+            android:textStyle="bold" />
+    </RelativeLayout>
 
         <!-- List of Actions (pages) -->
         <ListView
-            android:layout_below="@id/languageTitle"
             android:id="@+id/navList"
             android:layout_width="280dp"
             android:layout_height="match_parent"
-            android:choiceMode="multipleChoice"
-            android:background="#ffffffff" />
+            android:layout_below="@id/languageTitle"
+            android:background="#ffffffff"
+            android:choiceMode="multipleChoice" />
 
+        <Button
+            android:id="@+id/deleted_selected_lang_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentRight="true"
+            android:layout_margin="15dp"
+            android:elevation="10dp"
+            android:padding="10dp"
+            android:text="@string/delete_lang_button"
+            android:textColor="@android:color/white"
+            android:theme="@style/MyRaisedButton" />
     </RelativeLayout>
 
 </android.support.v4.widget.DrawerLayout>

--- a/playphrase/src/main/res/layout/recording_fragment.xml
+++ b/playphrase/src/main/res/layout/recording_fragment.xml
@@ -4,11 +4,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="center"
+    android:layout_margin="15dp"
     android:background="#2693ff"
+    android:configChanges="keyboard|keyboardHidden|orientation"
     android:elevation="20dp"
     android:orientation="vertical"
-    android:padding="10dp"
-    android:configChanges="keyboard|keyboardHidden|orientation">
+    android:padding="10dp">
 
     <RelativeLayout
         android:id="@+id/header"
@@ -46,11 +47,11 @@
             android:id="@+id/phrase_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_gravity="fill_horizontal"
             android:background="#FAFFEB"
+            android:entries="@array/Phrase_choices"
             android:outlineProvider="bounds"
             android:padding="12dp"
-            android:layout_gravity="fill_horizontal"
-            android:entries="@array/Phrase_choices"
             android:prompt="@string/Choose_Phrase_prompt"
         />
         <EditText
@@ -58,11 +59,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Phrase..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -70,8 +71,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -94,10 +95,10 @@
             android:id="@+id/category_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Category_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Category_prompt"
         />
         <EditText
@@ -106,10 +107,10 @@
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
             android:elevation="26dp"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
-            android:padding="12dp"
             android:hint="Category..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -117,8 +118,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
             />
@@ -141,10 +142,10 @@
             android:id="@+id/language_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="#FAFFEB"
-            android:padding="12dp"
             android:layout_gravity="fill_horizontal"
+            android:background="#FAFFEB"
             android:entries="@array/Language_choices"
+            android:padding="12dp"
             android:prompt="@string/Choose_Language_prompt"
         />
         <EditText
@@ -152,11 +153,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Language..."
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <EditText
@@ -165,11 +166,11 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/newLanguageText"
             android:background="#FFFFFFFF"
-            android:inputType="text|textCapSentences"
-            android:imeOptions="actionDone"
             android:elevation="26dp"
-            android:padding="12dp"
             android:hint="Abbreviation (4 Letters)"
+            android:imeOptions="actionDone"
+            android:inputType="text|textCapSentences"
+            android:padding="12dp"
             android:visibility="invisible"
         />
         <ImageButton
@@ -177,8 +178,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_clear_red_600_24dp"
             android:background="#FFFFFFFF"
+            android:src="@drawable/ic_clear_red_600_24dp"
             android:text="Cancel"
             android:visibility="invisible"
         />
@@ -195,8 +196,8 @@
         android:id="@+id/btn_layout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_below="@+id/spacer3">
+        android:layout_below="@+id/spacer3"
+        android:layout_gravity="center_horizontal">
 
         <dragon.tamu.playphrase.VisualizerView
             android:id="@+id/visualizer_view"
@@ -206,22 +207,22 @@
             android:id="@+id/btnPlay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_play_arrow_green_700_48dp"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="10dp"
+            android:src="@drawable/ic_play_arrow_green_700_48dp"
         />
         <ImageButton
             android:id="@+id/btnPause"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentLeft="true"
-            android:src="@drawable/ic_pause_green_700_48dp"
-            android:visibility="invisible"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="10dp"
+            android:src="@drawable/ic_pause_green_700_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnStartRecording"
@@ -229,10 +230,10 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
-            android:visibility="visible"
             android:background="#2693ff"
             android:padding="10dp"
+            android:src="@drawable/ic_fiber_manual_record_red_600_48dp"
+            android:visibility="visible"
         />
         <ImageButton
             android:id="@+id/btnStopRecording"
@@ -240,21 +241,21 @@
             android:layout_height="wrap_content"
             android:layout_below="@+id/visualizer_view"
             android:layout_centerInParent="true"
-            android:src="@drawable/ic_stop_red_600_48dp"
-            android:visibility="invisible"
             android:background="#2693ff"
             android:padding="10dp"
+            android:src="@drawable/ic_stop_red_600_48dp"
+            android:visibility="invisible"
         />
         <ImageButton
             android:id="@+id/btnSubmit"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/visualizer_view"
             android:layout_alignParentRight="true"
-            android:src="@drawable/ic_save_black_48dp"
-            android:text="Save"
+            android:layout_below="@+id/visualizer_view"
             android:background="#2693ff"
             android:padding="10dp"
+            android:src="@drawable/ic_save_black_48dp"
+            android:text="Save"
         />
     </RelativeLayout>
 </RelativeLayout>

--- a/playphrase/src/main/res/values/strings.xml
+++ b/playphrase/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="swipe_instr">Swipe right to delete...</string>
     <string name="add_category">Add Category</string>
     <string name="add_phrase">Add Phrase</string>
+    <string name="delete_lang_button">Deleted Selected</string>
 
     <string name = "Choose_Phrase_prompt">Select Phrase...</string>
     <string-array name = "Phrase_choices">

--- a/playphrase/src/main/res/values/styles.xml
+++ b/playphrase/src/main/res/values/styles.xml
@@ -8,4 +8,9 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="MyRaisedButton" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorControlHighlight">@color/colorAccent</item>
+        <item name="colorButtonNormal">@color/colorPrimary</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
-Integrate Jacob's changes
-(DONE)Add background to fragments and buttons to not allow overlap to distract
-Disallow Uncategorized from being deleted
-(DONE)Figure out langauge sortin
-Add abbreviations to phrases on both edit AND main activity screens
-(DONE)Add a way to delete a language
-Add a back button to edit screen

Noticed bugs
When a phrase is deleted and then the add phrase fragment is brought up, that phrase is still there.
Similarly, newly added phrases dont show up if the add phrase fragment is brought up more than once within a single session of EditActivity
(FIXED)The phrases are also getting added to uncategorized
If an already existing phrase is having language overwritten, the save button does nothing and we're stuck on the "New Recording" Screen
(FIXED)Adding a new langauge to a phrase that already exists adds a duplicate phrase to the list.

Some possible enhancements:
Add a label above the spinners in the add phrase fragment
For purposes of avoiding substring errors, make '[' and ']' illegal characters in language and language abbreviation
